### PR TITLE
Update README with local setup steps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env and set your API key
+GEMINI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ APIs.
 pip install google-genai
 ```
 
+Alternatively, clone this repository and install the dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Copy `.env.example` to `.env` and add your `GEMINI_API_KEY`.
+
+### Running the pipeline and chat
+
+```bash
+python main.py pipeline path/para/WhatsApp.zip
+python main.py chat
+```
+
 ## Imports
 
 ```python


### PR DESCRIPTION
## Summary
- document installing from requirements
- show how to run pipeline and chat commands
- add `.env.example` placeholder for `GEMINI_API_KEY`

## Testing
- `pytest google/genai/tests/imports/test_no_optional_imports.py -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_6855062025048327aa9237ed1aa22ecb