### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,10 @@ typing_extensions==4.12.2
 urllib3==2.2.3
 websockets==15.0.0
 mcp==1.8.1; python_version > '3.9'
+pdfminer.six
+Pillow
+ffmpeg-python
+openai-whisper
+python-dotenv
+google-genai
+rich


### PR DESCRIPTION
## Summary
- add packages for PDF, audio and environment helpers to requirements.txt

## Testing
- `pytest google/genai/tests/imports/test_no_optional_imports.py` *(fails: ModuleNotFoundError: No module named 'google')*
- `mypy google/genai/ --strict --config-file=google/genai/mypy.ini` *(fails: internal error)*

------
https://chatgpt.com/codex/tasks/task_e_6855061d7f988327bcc68e9325273344